### PR TITLE
Used mapped content directory path to check for custom ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,7 @@
 A Chassis extension that allows you to overwrite the default `php.ini` configuration values so you can tailor your Chassis box to match your server requirements.
 
 ## Usage
-
-1. Add your custom [php.ini](http://php.net/manual/en/ini.core.php) values to `modules/phpini/templates/custom.ini.erb`
-2. Run `vagrant provision`
-3. To check the values have been applied you can browse to [http://vagrant.local/phpinfo.php](http://vagrant.local/phpinfo.php).
-
-## Adding your custom ini configuration to version control.
-1. Add a `custom.ini` file inside your `content` directory.
+1. Add a `custom.ini` file inside your `content` directory with your [custom configuration](http://php.net/manual/en/ini.core.php). e.g. `memory_limit = 512M`
 2. Commit that to your Git repository.
-3. Run `vagrant provision`. If your `content` folder contains a `custom.ini` file it will take precedence over any edits to `modules/phpini/templates/custom.ini.erb`. 
+3. Run `vagrant provision`.
+4. To check the values have been applied you can browse to [http://vagrant.local/phpinfo.php](http://vagrant.local/phpinfo.php).

--- a/modules/phpini/manifests/init.pp
+++ b/modules/phpini/manifests/init.pp
@@ -30,16 +30,18 @@ class phpini (
 		$php_dir = "php/${short_ver}"
 	}
 
+	$content_dir = $config[mapped_paths][content]
+
 	exec { 'copy_fpm_ini':
 		path    => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
-		command => "cp /vagrant/content/custom.ini /etc/${php_dir}/fpm/conf.d/custom.ini",
-		onlyif  => 'test -f /vagrant/content/custom.ini'
+		command => "cp ${content_dir}/custom.ini /etc/${php_dir}/fpm/conf.d/custom.ini",
+		onlyif  => "test -f ${content_dir}/custom.ini"
 	}
 
 	exec { 'copy_cli_ini':
 		path    => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
-		command => "cp /vagrant/content/custom.ini /etc/${php_dir}/cli/conf.d/custom.ini",
-		onlyif  => 'test -f /vagrant/content/custom.ini'
+		command => "cp ${content_dir}/custom.ini /etc/${php_dir}/cli/conf.d/custom.ini",
+		onlyif  => "test -f ${content_dir}/custom.ini"
 	}
 
 	file {

--- a/modules/phpini/manifests/init.pp
+++ b/modules/phpini/manifests/init.pp
@@ -34,28 +34,17 @@ class phpini (
 
 	exec { 'copy_fpm_ini':
 		path    => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
-		command => "cp ${content_dir}/custom.ini /etc/${php_dir}/fpm/conf.d/custom.ini",
-		onlyif  => "test -f ${content_dir}/custom.ini"
+		command => "cp -f ${content_dir}/custom.ini /etc/${php_dir}/fpm/conf.d/custom.ini",
+		onlyif  => "test -f ${content_dir}/custom.ini",
+		require => Package["${php_package}-fpm"],
+		notify  => Service["${php_package}-fpm"]
 	}
 
 	exec { 'copy_cli_ini':
 		path    => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
-		command => "cp ${content_dir}/custom.ini /etc/${php_dir}/cli/conf.d/custom.ini",
-		onlyif  => "test -f ${content_dir}/custom.ini"
-	}
-
-	file {
-			[
-					"/etc/${php_dir}/fpm/conf.d/custom.ini",
-					"/etc/${php_dir}/cli/conf.d/custom.ini"
-			]:
-		ensure  => $file,
-		content => template('phpini/custom.ini.erb'),
-		owner   => 'root',
-		group   => 'root',
-		mode    => '0644',
+		command => "cp -f ${content_dir}/custom.ini /etc/${php_dir}/cli/conf.d/custom.ini",
+		onlyif  => "test -f ${content_dir}/custom.ini",
 		require => Package["${php_package}-fpm"],
-		notify  => Service["${php_package}-fpm"],
-		replace => true
+		notify  => Service["${php_package}-fpm"]
 	}
 }

--- a/modules/phpini/templates/custom.ini.erb
+++ b/modules/phpini/templates/custom.ini.erb
@@ -1,2 +1,0 @@
-# Enter your custom php.ini configuration here and run `vagrant provision` to apply them.
-# memory_limit = 64M


### PR DESCRIPTION
This extension won't work for anyone using custom paths right now as it's hard coded to the `/vagrant/content` directory

Fixes #12 